### PR TITLE
fixing deployment after renaming the repo to hopfenstop.github.io

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,6 @@
  * @type {import('gatsby').GatsbyConfig}
  */
 module.exports = {
-  pathPrefix: "/hopfenstop-light",
   siteMetadata: {
     title: `HopfenStop PWA`,
     siteUrl: `https://www.pwa.hopfenstop.de`,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
+    "deploy": "gatsby build && gh-pages -d public"
   },
   "dependencies": {
     "@emotion/react": "^11.10.6",


### PR DESCRIPTION
Closes #6 

For more info see: https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages/