### PR TITLE
Fix gatsby build by checking for window in app bar

### DIFF
--- a/src/components/app_bar.js
+++ b/src/components/app_bar.js
@@ -6,7 +6,6 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
-import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -67,7 +66,10 @@ const NavBar = ({ pageTitle }) => {
     </Box>
   );
 
-  const container = document.querySelector('body');
+  let container;
+  if (typeof window !== "undefined") {
+    container = document.querySelector('body');
+  }
 
   return (
     <Box sx={{ display: 'flex' }}>


### PR DESCRIPTION
Gatsby build was broken due to https://github.com/hopfenstop/hopfenstop.github.io/pull/12.
Background: Browser context variables, like document are only accessible when the component is mounted client-side.