### PR TITLE
Simplify kiosk url, better for sharing

### DIFF
--- a/src/components/kiosk_map_overview.js
+++ b/src/components/kiosk_map_overview.js
@@ -78,7 +78,7 @@ const KioskMap = function () {
               eventHandlers={{
                 click: function (event) {
                   navigate(
-                    '/kiosk_detail_view?kiosk_id=' + event.target.options.id
+                    '/kiosk?id=' + event.target.options.id
                   );
                 },
               }}

--- a/src/pages/kiosk.js
+++ b/src/pages/kiosk.js
@@ -10,7 +10,7 @@ import { navigate } from 'gatsby';
 
 const KioskDetailView = ({location}) => {
     const params = new URLSearchParams(location.search);
-    var kioskId = params.get('kiosk_id')
+    var kioskId = params.get('id')
     const kiosk = kioskData.find(item => item.kioskId === kioskId);
 
     let coordinates;


### PR DESCRIPTION
Before: `kiosk_detail_view/?kiosk_id=1677a99f-21f5-4719-a81e-37a42e4943cd`
After: `/kiosk/?id=1677a99f-21f5-4719-a81e-37a42e4943cd`